### PR TITLE
Fix for systemd on ubuntu 16.04 server

### DIFF
--- a/roles/tableau/defaults/main.yml
+++ b/roles/tableau/defaults/main.yml
@@ -21,6 +21,7 @@ tableau_url_rpm: "https://downloads.tableau.com/esdalt/{{ tableau_version_major 
 tableau_postgresql_odbc_package: tableau-postgresql-odbc_9.5.3_amd64.deb
 tableau_postgresql_odbc_deb: "https://downloads.tableau.com/drivers/linux/deb/tableau-driver/{{ tableau_postgresql_odbc_package }}"
 
+tableau_fix_systemd_unit: false
 # User
 tableau_user: tabadmin
 tableau_password: azertyuiop

--- a/roles/tableau/tasks/install.yml
+++ b/roles/tableau/tasks/install.yml
@@ -16,6 +16,14 @@
   shell: "ls {{ tsm_packages }} | grep scripts"
   register: tsm
 
+- name: TABLEAU INSTALL | Fix systemd unit
+  lineinfile:
+    path: "{{ tsm_packages }}/{{ tsm.stdout }}/user-at.service"
+    line: Environment=XDG_RUNTIME_DIR=/run/user/%i
+    insertbefore: "^ExecStart="
+    state: present
+  when: tableau_fix_systemd_unit
+
 - name: TABLEAU INSTALL | Initialize Tableau TSM
   command: ./initialize-tsm {{ tsm_execute_args }} -f
   args:


### PR DESCRIPTION
On ubuntu 16.04 server the tableau provided unit file doesn't work because of a missing environment variable.

This PR add a var `tableau_fix_systemd_unit` with a default to false to choose to fix the unit file.