### PR TITLE
Create ssl helper

### DIFF
--- a/roles/tableau/defaults/main.yml
+++ b/roles/tableau/defaults/main.yml
@@ -21,6 +21,7 @@ tableau_url_rpm: "https://downloads.tableau.com/esdalt/{{ tableau_version_major 
 tableau_postgresql_odbc_package: tableau-postgresql-odbc_9.5.3_amd64.deb
 tableau_postgresql_odbc_deb: "https://downloads.tableau.com/drivers/linux/deb/tableau-driver/{{ tableau_postgresql_odbc_package }}"
 
+tableau_fix_systemd_unit: false
 # User
 tableau_user: tabadmin
 tableau_password: azertyuiop

--- a/roles/tableau/defaults/main.yml
+++ b/roles/tableau/defaults/main.yml
@@ -52,3 +52,6 @@ tsm_deploy_examples: false
 
 tabcmd_admin_username: admin
 tabcmd_admin_password: DhnfIZen3dj3d9s2
+
+# Ssl
+tableau_setup_ssl_helper: false

--- a/roles/tableau/defaults/main.yml
+++ b/roles/tableau/defaults/main.yml
@@ -55,3 +55,5 @@ tabcmd_admin_password: DhnfIZen3dj3d9s2
 
 # Ssl
 tableau_setup_ssl_helper: false
+tableau_ssl_certs_dir: "/etc/tableaussl/"
+tableau_ssl_key_ext: ".key.pem"

--- a/roles/tableau/handlers/main.yml
+++ b/roles/tableau/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Start tableau
-  command: "{{ TSM_EXECUTBALE }}/tsm start"
+  command: "{{ TSM_EXECUTABLE }}/tsm start"
 
 - name: Stop tableau
-  command: "{{ TSM_EXECUTBALE }}/tsm stop"
+  command: "{{ TSM_EXECUTABLE }}/tsm stop"
 
 - name: Apply pending changes
-  command: "{{ TSM_EXECUTBALE }}/tsm pending-changes apply -r --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm pending-changes apply -r --username {{ tableau_user }} --password {{ tableau_password }}"

--- a/roles/tableau/tasks/config.yml
+++ b/roles/tableau/tasks/config.yml
@@ -6,16 +6,16 @@
 
 - name: TABLEAU CONFIG | Set facts for Tableau Server Manager executable
   set_fact:
-    TSM_EXECUTBALE: "{{ tsm_packages }}/{{ item.stdout }}"
+    TSM_EXECUTABLE: "{{ tsm_packages }}/{{ item.stdout }}"
   with_items:
     - "{{ tsm }}"
 
 - name: TABLEAU CONFIG | Set Tableau Server licence
-  command: "{{ TSM_EXECUTBALE }}/tsm licenses activate -k {{ tsm_licence }} --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm licenses activate -k {{ tsm_licence }} --username {{ tableau_user }} --password {{ tableau_password }}"
   when: tsm_licence != ""
 
 - name: TABLEAU CONFIG | Get free trial Tableau Server licence
-  command: "{{ TSM_EXECUTBALE }}/tsm licenses activate -t --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm licenses activate -t --username {{ tableau_user }} --password {{ tableau_password }}"
   when: tsm_licence == ""
 
 - name: TABLEAU CONFIG | Copy Tableau Server registration file
@@ -27,7 +27,7 @@
     mode: 0644
 
 - name: TABLEAU CONFIG | Register Tableau Server
-  command: "{{ TSM_EXECUTBALE }}/tsm register --file /tmp/tableau_registration_file.json --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm register --file /tmp/tableau_registration_file.json --username {{ tableau_user }} --password {{ tableau_password }}"
 
 - name: TABLEAU CONFIG | Copy Tableau Server identity stores
   template:
@@ -38,19 +38,19 @@
     mode: 0644
 
 - name: TABLEAU CONFIG | Configure Tableau Server identity stores
-  command: "{{ TSM_EXECUTBALE }}/tsm settings import -f /tmp/tableau_identity_file.json --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm settings import -f /tmp/tableau_identity_file.json --username {{ tableau_user }} --password {{ tableau_password }}"
 
 - name: TABLEAU CONFIG | Configure Tableau Server to not deploy examples
-  command: "{{ TSM_EXECUTBALE }}/tsm configuration set -k install.component.samples -v false --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm configuration set -k install.component.samples -v false --username {{ tableau_user }} --password {{ tableau_password }}"
   when: not tsm_deploy_examples
 
 - name: TABLEAU CONFIG | Apply pending changes
-  command: "{{ TSM_EXECUTBALE }}/tsm pending-changes apply --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm pending-changes apply --username {{ tableau_user }} --password {{ tableau_password }}"
 
 - name: TABLEAU CONFIG | Initialize Tableau Server (This may take some time)
-  command: "{{ TSM_EXECUTBALE }}/tsm initialize --start-server --request-timeout 1800 --username {{ tableau_user }} --password {{ tableau_password }}"
+  command: "{{ TSM_EXECUTABLE }}/tsm initialize --start-server --request-timeout 1800 --username {{ tableau_user }} --password {{ tableau_password }}"
   args:
     creates: /tmp/tableau_init.done
 
 - name: TABLEAU CONFIG | Configure Tableau Server administrator user
-  command: '{{ TSM_EXECUTBALE }}/tabcmd initialuser --server "localhost:80" --username "{{ tabcmd_admin_username }}" --password "{{ tabcmd_admin_password }}"'
+  command: '{{ TSM_EXECUTABLE }}/tabcmd initialuser --server "localhost:80" --username "{{ tabcmd_admin_username }}" --password "{{ tabcmd_admin_password }}"'

--- a/roles/tableau/tasks/install.yml
+++ b/roles/tableau/tasks/install.yml
@@ -16,6 +16,14 @@
   shell: "ls {{ tsm_packages }} | grep scripts"
   register: tsm
 
+- name: TABLEAU INSTALL | Fix systemd unit
+  lineinfile:
+    path: "{{ tsm_packages }}/{{ tsm.stdout }}/user-at.service"
+    line: Environment=XDG_RUNTIME_DIR=/run/user/%i
+    insertbefore: "^ExecStart="
+    state: present
+  when: tableau_fix_systemd_unit
+
 - name: TABLEAU INSTALL | Initialize Tableau TSM
   command: ./initialize-tsm {{ tsm_execute_args }} -f
   args:

--- a/roles/tableau/tasks/main.yml
+++ b/roles/tableau/tasks/main.yml
@@ -23,3 +23,8 @@
 - name: TABLEAU | Install Postgresql Tableau ODBC
   import_tasks: postgresql.yml
   tags: odbc
+
+- name: TABLEAU | Create ssl reload helper
+  import_tasks: ssl.yml
+  tags: ssl
+  when: tableau_setup_ssl_helper

--- a/roles/tableau/tasks/ssl.yml
+++ b/roles/tableau/tasks/ssl.yml
@@ -1,0 +1,15 @@
+- name: Create ssl reload helper directory
+  file:
+    state: directory
+    path: /etc/tableaussl
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Create ssl reload helper
+  template:
+    src: ssl_reload_helper
+    dest: /etc/tableaussl/reload_command
+    owner: root
+    group: root
+    mode: 0700

--- a/roles/tableau/templates/ssl_reload_helper
+++ b/roles/tableau/templates/ssl_reload_helper
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+script_dir="{{ TSM_EXECUTBALE }}"
+cert_dir=$(dirname "$0")
+
+key_file=$(ls "$cert_dir"/*.key | head -n 1)
+crt_file="$cert_dir$(basename "$key_file" .key).crt"
+
+"$script_dir/tsm" security external-ssl enable --username "{{ tableau_user }}" --password "{{ tableau_password }}"  --cert-file "$crt_file" --key-file "$key_file"
+"$script_dir/tsm" pending-changes apply --ignore-prompt enable --username "{{ tableau_user }}" --password "{{ tableau_password }}"

--- a/roles/tableau/templates/ssl_reload_helper
+++ b/roles/tableau/templates/ssl_reload_helper
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-script_dir="{{ TSM_EXECUTBALE }}"
+script_dir="{{ TSM_EXECUTABLE }}"
 cert_dir=$(dirname "$0")
 
 key_file=$(ls "$cert_dir"/*.key | head -n 1)

--- a/roles/tableau/templates/ssl_reload_helper
+++ b/roles/tableau/templates/ssl_reload_helper
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 script_dir="{{ TSM_EXECUTABLE }}"
-cert_dir=$(dirname "$0")
+cert_dir="{{ tableau_ssl_certs_dir }}"
 
-key_file=$(ls "$cert_dir"/*.key | head -n 1)
-crt_file="$cert_dir$(basename "$key_file" .key).crt"
+key_file=$(ls "$cert_dir"/*{{ tableau_ssl_key_ext }}  | head -n 1)
+crt_file="$cert_dir$(basename "$key_file" {{ tableau_ssl_key_ext }}).crt"
 
 "$script_dir/tsm" security external-ssl enable --username "{{ tableau_user }}" --password "{{ tableau_password }}"  --cert-file "$crt_file" --key-file "$key_file"
 "$script_dir/tsm" pending-changes apply --ignore-prompt enable --username "{{ tableau_user }}" --password "{{ tableau_password }}"


### PR DESCRIPTION
This PR adds an optionally generated script to handle ssl activation and renewal.
It aims at being used as a reload command in case of let's encrypt renewal.
It looks for certs in `tableau_ssl_certs_dir` for a key file with `tableau_ssl_key_ext` extension. It expects the certificate to share its name with the key but with .crt extension.
Also I fix a typo in a fact name