### PR TITLE
defaults: fix missing 'tableau_ssl_crt_ext' default variable

### DIFF
--- a/roles/tableau/defaults/main.yml
+++ b/roles/tableau/defaults/main.yml
@@ -58,4 +58,4 @@ tabcmd_admin_password: DhnfIZen3dj3d9s2
 tableau_setup_ssl_helper: false
 tableau_ssl_certs_dir: "/etc/tableaussl/"
 tableau_ssl_key_ext: ".key.pem"
-tableau_ssl_key_ext: ".crt"
+tableau_ssl_crt_ext: ".crt"


### PR DESCRIPTION
Fixing a typo introduced with #8